### PR TITLE
Refactor Makefile to use /usr/local & standard variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-DESTDIR=/opt/isidore
-BINDIR=$(DESTDIR)/bin
-DOCDIR=$(DESTDIR)/share/doc/isidore
+DESTDIR=
+PREFIX=/usr/local
+BINDIR=$(PREFIX)/bin
+DOCDIR=$(PREFIX)/share/doc/isidore
 
 .PHONY: install install-bin install-doc all clean
 
@@ -13,13 +14,13 @@ clean:
 install: install-bin install-doc install-lib
 
 install-bin:
-	mkdir -p "$(BINDIR)"
-	cp -r bin/* "$(BINDIR)/"
+	mkdir -p "$(DESTDIR)$(BINDIR)"
+	cp -r bin/* "$(DESTDIR)$(BINDIR)/"
 
 install-lib:
 	$(MAKE) -C lib install
 
 install-doc:
-	mkdir -p "$(DOCDIR)"
-	cp -r doc/* "$(DOCDIR)/"
+	mkdir -p "$(DESTDIR)$(DOCDIR)"
+	cp -r doc/* "$(DESTDIR)$(DOCDIR)/"
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -25,7 +25,7 @@ care to change the specified values as necessary.
 1. Your MariaDB/MySQL server is `localhost`.
 2. The database you wish to use will be named `isidore`.
 3. The user you wish to use to access the database will be named `isidore`.
-4. You are installing to `/opt/isidore`.
+4. You are installing to `/usr/local`.
 
 Installation
 ------------
@@ -46,9 +46,9 @@ Install the binaries and associated documentation.
 
 #### Installation Directory
 
-Isidore uses a non-standard directory structure, so by default it installs to
-`/opt/isidore`. This directory can be changed by setting the `DESTDIR` variable
-via either the environment or an additional argument to the `make` command.
+By default Isidore installs to `/usr/local`. This directory can be changed by
+setting the `PREFIX` variable via either the environment or an additional
+argument to the `make` command.
 
 #### Perform the Installation
 
@@ -115,5 +115,5 @@ field under the `[database]` section to match the password you set in step 2.
 You're now ready to start using Isidore. Start the Isidore command prompt using
 the following command:
 
-    /opt/isidore/bin/isidore
+    /usr/local/bin/isidore
 

--- a/doc/query.md
+++ b/doc/query.md
@@ -120,19 +120,19 @@ a format as the second argument like so:
 
 There is also an `inventory` Python script provided with the Isidore
 installation. It resides in your Isidore binary directory (by default
-/opt/isidore/bin). To print the inventory this way, run:
+/usr/local/bin). To print the inventory this way, run:
 
-    solo@han:~$ /opt/isidore/bin/inventory
+    solo@han:~$ /usr/local/bin/inventory
 
 This script is also suitable for use as an Ansible inventory source. For
 example, the following can be used to run the site.yml playbook on the Isidore
 inventory:
 
-    solo@han:ansible$ ansible-playbook site.yml -i /opt/isidore/bin/inventory
+    solo@han:ansible$ ansible-playbook site.yml -i /usr/local/bin/inventory
 
 Or to just list the contents of the inventory:
 
-    solo@han:ansible$ ansible-inventory -i /opt/isidore/bin/inventory --list
+    solo@han:ansible$ ansible-inventory -i /usr/local/bin/inventory --list
 
 ## 4. Printing the Isidore Configuration
 


### PR DESCRIPTION
The directory structure for Isidore has been standardized so now we can install directly to /usr/local and play nice :)