### PR TITLE
Z5t1 yaml inv

### DIFF
--- a/doc/query.md
+++ b/doc/query.md
@@ -109,9 +109,11 @@ inventory` command:
     
     >
 
-Additionally, the inventory can be printed in YAML or JSON format by specifying
-a format as the second argument like so:
+Additionally, the inventory can be printed in human friendly, YAML or JSON
+format by specifying a format as the second argument like so:
 
+    > show inventory human
+    [output ommitted]
     > show inventory yaml
     [output ommitted]
     > show inventory json

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -240,10 +240,13 @@ tags        print all tags in the database''')
         elif args[2] == '?':
             print('''\
 ?           print this help message
+human       print the inventory in a human friendly format
 ini         print the inventory in INI format
 json        print the inventory in JSON format
 yaml        print the inventory in YAML format''')
 
+        elif args[2] == 'human':
+            print(yaml.dump(self._isidore.getInventory(), default_flow_style=False))
         elif args[2] == 'ini':
             print(self._isidore.getInventoryIni())
         elif args[2] == 'json':


### PR DESCRIPTION
Make the `show inventory yaml` output compliant with the Ansible YAML inventory format specification. Since the old behavior was more human friendly/readable, it has been retained as `show inventory human`.