### PR TITLE
Fix list variable appending with MySQL

### DIFF
--- a/lib/src/isidore/libIsidore.py
+++ b/lib/src/isidore/libIsidore.py
@@ -500,7 +500,9 @@ class Host:
             UPDATE Host
             SET Variables =
                 JSON_ARRAY_APPEND(
-                    (SELECT Variables FROM Host WHERE HostId = %s),
+                    (SELECT Variables
+                        FROM (SELECT * FROM Host) AS temp
+                        WHERE HostId = %s),
                     %s,
                     JSON_EXTRACT(%s, '$')
                 )
@@ -789,7 +791,9 @@ class Tag:
             UPDATE Tag
             SET Variables =
                 JSON_ARRAY_APPEND(
-                    (SELECT Variables FROM Tag WHERE TagID = %s),
+                    (SELECT Variables
+                        FROM (SELECT * FROM Tag) AS temp
+                        WHERE TagId = %s),
                     %s,
                     JSON_EXTRACT(%s, '$')
                 )


### PR DESCRIPTION
The old syntax works fine with MariaDB but does not work with MySQL. The new syntax works on both databases. See
https://stackoverflow.com/questions/4429319/you-cant-specify-target-table-for-update-in-from-clause