### PR TITLE
Add describe commands

### DIFF
--- a/doc/query.md
+++ b/doc/query.md
@@ -26,6 +26,27 @@ To list all the decommissioned hosts in the Isidore database, use the
     beru
     >
 
+To list all the commissioned hosts along with their descriptions, use the
+`describe hosts` command.
+
+    > describe hosts
+    chewy: null
+    han: Disorganized development laptop. Sorry about this mess.
+    leia: null
+    luke: 'He''s just not a farm boy:'
+    obi-wan: null
+    yoda: null
+    
+    >
+
+Similarly to list all the decommissioned hosts with their descriptions, use the
+`describe graveyard` command.
+
+    > describe graveyard
+    beru: null
+    
+    >
+
 ## 2. Listing Tags
 
 To list all the tags in the Isidore database, use the `show tags` command.
@@ -45,9 +66,65 @@ To list all the tags in the Isidore database organized by group, use the
 `show tag-groups` command.
 
     > show tag-groups
-    location (cherryhill, newark, princeton)
-    physicality (physical, virtual)
-    type (laptop, server, workstation)
+    location:
+    - cherryhill
+    - newark
+    - princeton
+    physicality:
+    - physical
+    - virtual
+    type:
+    - laptop
+    - server
+    - workstation
+    ungrouped:
+    - all
+    - ungrouped
+
+    >
+
+To list all the tags along with their descriptions, use the `describe tags`
+command.
+
+    > describe tags
+    all: Special tag that applies to all hosts. The host list is ignored for this tag;
+      it will always apply to every host in Isidore.
+    cherryhill: Cherry Hill, NJ
+    laptop: Laptops
+    newark: Newark, NJ
+    physical: Physical Machines
+    princeton: Princeton, NJ
+    server: Servers
+    ungrouped: Special tag that applies to hosts that do not have a tag. In addition to
+      any hosts assigned to this tag, it will always apply to every host that does not
+      have a tag.
+    virtual: Virtual Machines
+    workstation: Workstations
+
+    >
+
+Similarly, the `describe tag-groups` command can be used to list all the tags
+and their details by group.
+
+    > describe tag-groups
+    location:
+    - cherryhill: Cherry Hill, NJ
+    - newark: Newark, NJ
+    - princeton: Princeton, NJ
+    physicality:
+    - physical: Physical Machines
+    - virtual: Virtual Machines
+    type:
+    - laptop: Laptops
+    - server: Servers
+    - workstation: Workstations
+    ungrouped:
+    - all: Special tag that applies to all hosts. The host list is ignored for this tag;
+        it will always apply to every host in Isidore.
+    - ungrouped: Special tag that applies to hosts that do not have a tag. In addition
+        to any hosts assigned to this tag, it will always apply to every host that does
+        not have a tag.
+    
     >
 
 ## 3. Printing the Inventory

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -1041,13 +1041,17 @@ remove      remove hosts from this tag''')
 ?           print this help message
 all         print all the information about the tag
 description print the tag's description
-group       print the date the tag was commissioned''')
+group       print the date the tag was commissioned
+hosts       print all hosts that have this tag''')
         elif args[3] == 'all':
             print(yaml.dump(tag.getDetails(), default_flow_style=False))
         elif args[3] == 'description':
             print(tag.getDescription())
         elif args[3] == 'group':
             print(tag.getGroup())
+        elif args[3] == 'hosts':
+            for host in tag.getHosts():
+                print(host.getHostname())
         else:
             print('Invalid argument '+args[3]+'. Enter ? for help.', file=sys.stderr)
 

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -547,7 +547,8 @@ var         display and modify this host's variables''')
 all         print all the information about the host
 commissioned    print the date the host was commissioned
 description     print the host's description
-decommissioned  print the date the host was decommissioned''')
+decommissioned  print the date the host was decommissioned
+tags        print the tags currently assigned to this host''')
         elif args[3] == 'all':
             print(yaml.dump(host.getDetails(), default_flow_style=False))
         elif args[3] == 'commissioned':
@@ -556,6 +557,9 @@ decommissioned  print the date the host was decommissioned''')
             print(host.getDescription())
         elif args[3] == 'decommissioned':
             print(host.getDecommissionDate())
+        elif args[3] == 'tags':
+            for tag in host.getTags():
+                print(tag.getName())
         else:
             print('Invalid argument '+args[3]+'. Enter ? for help.', file=sys.stderr)
 

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -653,7 +653,7 @@ remove      remove a tag from this host''')
                     'group': tag.getGroup(),
                     'description': tag.getDescription()
                     } )
-            print(yaml.dump(tags, default_flow_style=False))
+            print(yaml.dump(tags, default_flow_style=False, sort_keys=False))
 
         elif args[3] == 'remove':
             self.host_tag_remove(args)

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -977,10 +977,13 @@ Enter ? as any argument help.''', file=sys.stderr)
         elif args[2] == '?':
             print('''\
 ?           print this help message
+describe    print details about tag attributes
 host        display and modify hosts that have this tag
 set         modify tag attributes
 show        display tag attributes
 var         display and modify this tag's variables''')
+        elif args[2] == 'describe':
+            self.tag_describe(args)
         elif args[2] == 'host':
             self.tag_host(args)
         elif args[2] == 'set':
@@ -991,6 +994,23 @@ var         display and modify this tag's variables''')
             self.tag_var(args)
         else:
             print('Invalid command '+args[2]+'. Enter ? for help.', file=sys.stderr)
+
+    # > tag <tagname> describe
+    def tag_describe(self, args):
+        tag = self._isidore.getTag(args[1])
+        if len(args) == 3:
+            self.subprompt(args, self.tag_describe)
+        elif args[3] == '?':
+            print('''\
+?           print this help message
+hosts       describe the hosts currently assigned to this tag''')
+        elif args[3] == 'hosts':
+            hosts = {}
+            for host in tag.getHosts():
+                hosts[host.getHostname()] = host.getDescription()
+            print(yaml.dump(hosts, default_flow_style=False))
+        else:
+            print('Invalid argument '+args[3]+'. Enter ? for help.', file=sys.stderr)
 
     # > tag <tagname> host
     def tag_host(self, args):

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -521,10 +521,13 @@ tag         delete a tag''')
         elif args[2] == '?':
             print('''\
 ?           print this help message
+describe    print details about host attributes
 set         modify host attributes
 show        display host attributes
 tag         display and modify this host's tags
 var         display and modify this host's variables''')
+        elif args[2] == 'describe':
+            self.host_describe(args)
         elif args[2] == 'set':
             self.host_set(args)
         elif args[2] == 'show':
@@ -535,6 +538,23 @@ var         display and modify this host's variables''')
             self.host_var(args)
         else:
             print('Invalid command '+args[2]+'. Enter ? for help.', file=sys.stderr)
+
+    # > host <hostname> describe
+    def host_describe(self, args):
+        host = self._isidore.getHost(args[1])
+        if len(args) == 3:
+            self.subprompt(args, self.host_describe)
+        elif args[3] == '?':
+            print('''\
+?           print this help message
+tags        describe the tags currently assigned to this host''')
+        elif args[3] == 'tags':
+            tags = {}
+            for tag in host.getTags():
+                tags[tag.getName()] = tag.getDescription()
+            print(yaml.dump(tags, default_flow_style=False))
+        else:
+            print('Invalid argument '+args[3]+'. Enter ? for help.', file=sys.stderr)
 
     # > host <hostname> show
     def host_show(self, args):


### PR DESCRIPTION
Add a series of `describe` commands to supplement the `show` commands. The `describe` commands work like their corresponding `show` commands but they print the description along with each host/tag.