### PR TITLE
Insert rows into Metadata table if they don't exist

### DIFF
--- a/lib/src/isidore/libIsidore.py
+++ b/lib/src/isidore/libIsidore.py
@@ -511,7 +511,7 @@ class Isidore:
     # @param motd           The message of the day
     def setMotd(self, motd):
         cursor = self._conn.cursor()
-        stmt = "UPDATE Metadata SET Value = %s WHERE KeyName = 'motd'"
+        stmt = "REPLACE INTO Metadata (KeyName, Value) VALUES ('motd', %s)"
         cursor.execute(stmt, [ motd ])
         self._conn.commit()
         cursor.close()
@@ -520,7 +520,7 @@ class Isidore:
     # @param name           The name
     def setName(self, name):
         cursor = self._conn.cursor()
-        stmt = "UPDATE Metadata SET Value = %s WHERE KeyName = 'name'"
+        stmt = "REPLACE INTO Metadata (KeyName, Value) VALUES ('name', %s)"
         cursor.execute(stmt, [ name ])
         self._conn.commit()
         cursor.close()


### PR DESCRIPTION
Previously the name and motd rows were updated only if they already existed. Whereas they're not inserted as part of the initial database population, this resulted in the initial setting of the name and motd failing. This employs a more rugged solution that is elegant and allows for better backwards compability with older installations by not requiring the database to be repopulated from scratch.