### PR TITLE
Run each command as a separate SQL transaction

### DIFF
--- a/lib/src/isidore/libIsidore.py
+++ b/lib/src/isidore/libIsidore.py
@@ -507,6 +507,16 @@ class Isidore:
     def getVersion(self):
         return self._version
 
+    # Starts a new SQL transaction. All subsequent queries will operate on a
+    # snapshot of the database as it appeared either the last time this method
+    # was called or the last time it was written to, whichever is more recent.
+    # In the event that neither of these has happened since the object was
+    # instantiated, the queries run on a snapshot of the database at the time
+    # of instantiation.
+    def newTransaction(self):
+        self._conn.commit()
+        self._conn.start_transaction()
+
     # Sets the message of the day
     # @param motd           The message of the day
     def setMotd(self, motd):

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -74,6 +74,11 @@ class IsidoreCmdline:
                 print("Malformed command", file=sys.stderr)
                 continue
 
+            # Ensure each command runs as its own SQL transaction so each
+            # separate command operates on the latest data but still has
+            # repeatable reads/consistency within each command.
+            self._isidore.newTransaction()
+
             # Process input
             if line == []:
                 continue


### PR DESCRIPTION
Ensure each command runs as its own SQL transaction so each separate command operates on the latest data but still has repeatable reads/consistency within each command.